### PR TITLE
add logos to the .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^logos


### PR DESCRIPTION
When running the `check()` function, there was a note on the logos folder. Need to ignore it when building the package from source